### PR TITLE
Edit the README to mention --appimage-extract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # unappimage
 
 A lightweight AppImage extractor, forked from squashfs-tools's unsquashfs.
+
+Type two AppImages can extract themselves using the CLI argument `--appimage-extract`. However, type one AppImages do not have this feature, and as such may need tools such as unappimage.
+
+https://docs.appimage.org/user-guide/run-appimages.html#extract-the-contents-of-an-appimage


### PR DESCRIPTION
Since type 2 AppImages can extract themselves via `--appimage-extract`, it may be worth it to mention this in the README. Mainly suggesting this, as a number of apps on Flathub utilize unappimage when they can instead use the CLI argument.