### PR TITLE
unsquashfs: add missing parameter to fix function pointer mismatch

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -139,7 +139,7 @@ void prep_exit()
 }
 
 
-void sigwinch_handler()
+void sigwinch_handler(int sig)
 {
 	struct winsize winsize;
 
@@ -153,7 +153,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int sig)
 {
 	rotate = (rotate + 1) % 4;
 }


### PR DESCRIPTION
```
unsquashfs.c:2233:26: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
 2233 |         signal(SIGWINCH, sigwinch_handler);
      |                          ^~~~~~~~~~~~~~~~
      |                          |
      |                          void (*)(void)
In file included from unsquashfs.h:46,
                 from unsquashfs.c:26:
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
unsquashfs.c:142:6: note: ‘sigwinch_handler’ declared here
  142 | void sigwinch_handler()
      |      ^~~~~~~~~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
unsquashfs.c:2234:25: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
 2234 |         signal(SIGALRM, sigalrm_handler);
      |                         ^~~~~~~~~~~~~~~
      |                         |
      |                         void (*)(void)
/usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
   88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
      |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
unsquashfs.c:156:6: note: ‘sigalrm_handler’ declared here
  156 | void sigalrm_handler()
      |      ^~~~~~~~~~~~~~~
/usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
   72 | typedef void (*__sighandler_t) (int);
      |                ^~~~~~~~~~~~~~
```